### PR TITLE
PES-1486_phpcs_rules_improvement

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -72,6 +72,9 @@
     <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine" />
     <!-- don't allow opening class brace on new line -->
     <rule ref="Generic.Classes.OpeningBraceSameLine.BraceOnNewLine" />
+    <!-- if file has file comment, it must have 1 blank line after the comment -->
+    <rule ref="Squiz.Commenting.FileComment.SpacingAfterOpen" />
+    <rule ref="Squiz.Commenting.FileComment.SpacingAfterComment" />
 
     <!-- Rules taken from Slevomat coding standard -->
 
@@ -84,6 +87,33 @@
             <properties>
                 <property name="ignoreSpacesInAnnotation" value="true"/>
                 <property name="ignoreSpacesInComments" value="true"/>
+            </properties>
+    </rule>
+    <!-- force constructor parameters to be on multiple lines if more than 1 parameter exists -->
+    <rule ref="./phpcs/vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/Classes/RequireMultiLineMethodSignatureSniff.php">
+            <properties>
+                <property name="minParametersCount" value="2"/>
+                <property name="includedMethodPatterns" type="array">
+                    <element value="~__construct~"/>
+                </property>
+            </properties>
+    </rule>
+    <!-- require 1 blank line between different types of class members -->
+    <rule ref="./phpcs/vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/Classes/ClassMemberSpacingSniff.php" />
+    <!-- disallow blank lines after class opening brace and before class closing brace -->
+    <rule ref="./phpcs/vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/Classes/EmptyLinesAroundClassBracesSniff.php">
+            <properties>
+                <property name="linesCountAfterOpeningBrace" value="0"/>
+                <property name="linesCountBeforeClosingBrace" value="0"/>
+            </properties>
+    </rule>
+    <!-- disallow blank lines between class constants that have annotation, allow max 1 blank line between class constants without annotation-->
+    <rule ref="./phpcs/vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/Classes/ConstantSpacingSniff.php">
+            <properties>
+                <property name="minLinesCountBeforeWithComment" value="0"/>
+                <property name="maxLinesCountBeforeWithComment" value="0"/>
+                <property name="minLinesCountBeforeWithoutComment" value="0"/>
+                <property name="maxLinesCountBeforeWithoutComment" value="1"/>
             </properties>
     </rule>
 

--- a/phpcs/Packetery/Sniffs/Annotations/MethodAnnotationSniff.php
+++ b/phpcs/Packetery/Sniffs/Annotations/MethodAnnotationSniff.php
@@ -36,7 +36,7 @@ class MethodAnnotationSniff implements Sniff {
             $annotationFound = false;
             foreach ($paramAnnotations as $paramAnnotation) {
                 if ($paramAnnotation->getName() === '@param'
-                    && $paramAnnotation->getParameterName() === $paramName) {
+                    && $paramAnnotation->getValue()->parameterName === $paramName) {
                     $annotationFound = true;
                     break;
                 }
@@ -55,14 +55,20 @@ class MethodAnnotationSniff implements Sniff {
         }
 
         $missingAnnotations = [];
+        $presentAnnotationNames = [];
+        foreach ($annotations as $annotation) {
+            $presentAnnotationNames[] = $annotation->getName();
+        }
+
         foreach (self::REQUIRED_ANNOTATIONS as $requiredAnnotation) {
             if ($requiredAnnotation === '@return' && $methodName === '__construct') {
                 continue;
             }
-            if (!isset($annotations[$requiredAnnotation])) {
+            if (!in_array($requiredAnnotation, $presentAnnotationNames, true)) {
                 $missingAnnotations[] = $requiredAnnotation;
             }
         }
+
         if (!empty($missingAnnotations)) {
             $phpcsFile->addError(
                 sprintf(

--- a/phpcs/Packetery/Sniffs/Annotations/PropertyAnnotationSniff.php
+++ b/phpcs/Packetery/Sniffs/Annotations/PropertyAnnotationSniff.php
@@ -8,7 +8,6 @@ use SlevomatCodingStandard\Helpers\AnnotationHelper;
 use SlevomatCodingStandard\Helpers\PropertyHelper;
 
 class PropertyAnnotationSniff implements Sniff {
-
     /**
      * @return array
      */
@@ -26,7 +25,12 @@ class PropertyAnnotationSniff implements Sniff {
         $tokens = $phpcsFile->getTokens();
         if (PropertyHelper::isProperty($phpcsFile, $stackPtr)) {
             $annotations = AnnotationHelper::getAnnotations($phpcsFile, $stackPtr);
-            if (empty($annotations) || !isset($annotations['@var'])) {
+            $presentAnnotationNames = [];
+            foreach ($annotations as $annotation) {
+                $presentAnnotationNames[] = $annotation->getName();
+            }
+
+            if (!in_array('@var', $presentAnnotationNames, true)) {
                 $propertyName = $tokens[$stackPtr]['content'];
                 $phpcsFile->addError(
                     sprintf('Property %s is missing @var annotation', $propertyName),

--- a/phpcs/composer.json
+++ b/phpcs/composer.json
@@ -1,7 +1,7 @@
 {
     "require-dev": {
         "squizlabs/php_codesniffer": "3.*",
-        "slevomat/coding-standard": "8.0"
+        "slevomat/coding-standard": "8.*"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
solve constatnt spacing with and without annotation 
force constructor params on multiline if more than 1 
force file comment spacing if present
disallow empty line after class opening brace and before class closing brace
update slevomat package
fix broken Packetery sniffs after slevomat package update