### PR TITLE
PES-3151: update carriers feed integration and store availability state

### DIFF
--- a/CHANGE_LOG.txt
+++ b/CHANGE_LOG.txt
@@ -1,5 +1,6 @@
       - Added: Slovak translations
 2.1.4 - Added: Support for PHP 8.0 - 8.4
+      - Updated: carrier downloader now uses Packeta carriers feed v5
 2.1.3 - Fixed: session reference in shipping model
 2.1.2 - Updated: Add new fields to CSV export and update version number to 8
 2.1.1 - Updated: the icon for exporting checked orders differentiated from the icon for exporting all

--- a/upload/admin/model/extension/shipping/zasilkovna.php
+++ b/upload/admin/model/extension/shipping/zasilkovna.php
@@ -82,6 +82,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			`country` varchar(255) NOT NULL,
 			`currency` varchar(255) NOT NULL,
 			`max_weight` float NOT NULL,
+			`available` boolean NOT NULL DEFAULT 1,
 			`deleted` boolean NOT NULL,
 			UNIQUE (`id`)
 		) ENGINE=MyISAM;';
@@ -111,6 +112,10 @@ class ModelExtensionShippingZasilkovna extends Model {
 		if ($oldVersion && version_compare($oldVersion, '2.1.0') < 0) {
 			$queries[] = $this->getCreateCarriersTableSQL();
 			$queries[] = "ALTER TABLE `" . DB_PREFIX . "zasilkovna_weight_rules` DROP `min_weight`;";
+		} else if ($oldVersion && version_compare($oldVersion, '2.1.4') < 0) {
+			$queries[] = "ALTER TABLE `" . DB_PREFIX . "zasilkovna_carrier`
+				ADD COLUMN `available` boolean NOT NULL DEFAULT 1
+				AFTER `max_weight`;";
 		}
 
 		foreach ($queries as $query) {

--- a/upload/catalog/controller/extension/module/zasilkovna.php
+++ b/upload/catalog/controller/extension/module/zasilkovna.php
@@ -174,7 +174,7 @@ class ControllerExtensionModuleZasilkovna extends Controller {
 		try {
 			$carriers = $this->carriersDownloader->fetchAsArray();
 		} catch (DownloadException $e) {
-			echo sprintf($this->language->get('cron_download_failed'), $e->getMessage());
+			echo sprintf($this->language->get('cron_download_failed'), $this->resolveCarrierDownloadError($e->getMessage(), (int)$e->getCode()));
 			return;
 		}
 		if (!$carriers) {
@@ -188,6 +188,31 @@ class ControllerExtensionModuleZasilkovna extends Controller {
 		}
 		$this->carriersUpdater->saveCarriers($carriers);
 		echo $this->language->get('carriers_updated');
+	}
+
+	/**
+	 * @param string $errorMessage
+	 * @param int $errorCode
+	 * @return string
+	 */
+	private function resolveCarrierDownloadError($errorMessage, $errorCode)
+	{
+		if (
+			$errorMessage === CarriersDownloader::ERROR_DOWNLOAD_FAILED
+			&& $errorCode !== 0
+		) {
+			return sprintf($this->language->get('cron_download_failed_http'), $errorCode);
+		}
+
+		if ($errorMessage === CarriersDownloader::ERROR_DOWNLOAD_FAILED) {
+			return $this->language->get('cron_download_failed_generic');
+		}
+
+		if ($errorMessage === CarriersDownloader::ERROR_INVALID_JSON) {
+			return $this->language->get('cron_invalid_carriers');
+		}
+
+		return $errorMessage;
 	}
 
 }

--- a/upload/catalog/language/cs-cz/extension/shipping/zasilkovna.php
+++ b/upload/catalog/language/cs-cz/extension/shipping/zasilkovna.php
@@ -16,5 +16,7 @@ $_['shipping_any'] = 'Zásilkovna';
 $_['carriers_updated'] = 'Seznam dopravců byl aktualizován.';
 $_['please_provide_token'] = 'Správnou adresu pro aktualizaci dopravců naleznete na stránce modulu.';
 $_['cron_download_failed'] = 'Stažení dopravců se nezdařilo: %s Zkuste to prosím později.';
+$_['cron_download_failed_generic'] = 'Stažení feedu dopravců se nezdařilo.';
+$_['cron_download_failed_http'] = 'Stažení feedu dopravců se nezdařilo s HTTP kódem %s.';
 $_['cron_empty_carriers'] = 'Nepodařilo se získat jejich seznam.';
 $_['cron_invalid_carriers'] = 'Nevalidní odpověď API.';

--- a/upload/catalog/language/en-gb/extension/shipping/zasilkovna.php
+++ b/upload/catalog/language/en-gb/extension/shipping/zasilkovna.php
@@ -11,5 +11,7 @@ $_['shipping'] = 'Packeta';
 $_['carriers_updated'] = 'Carriers were updated.';
 $_['please_provide_token'] = 'You can find the correct address for updating carriers on the extension page.';
 $_['cron_download_failed'] = 'Carrier download failed: %s Please try again later.';
+$_['cron_download_failed_generic'] = 'Carrier feed download failed.';
+$_['cron_download_failed_http'] = 'Carrier feed download failed with HTTP code %s.';
 $_['cron_empty_carriers'] = 'Failed to get the list.';
 $_['cron_invalid_carriers'] = 'Invalid API response.';

--- a/upload/catalog/language/sk-sk/extension/shipping/zasilkovna.php
+++ b/upload/catalog/language/sk-sk/extension/shipping/zasilkovna.php
@@ -16,5 +16,7 @@ $_['shipping_any'] = 'Packeta';
 $_['carriers_updated'] = 'Zoznam dopravcov bol aktualizovaný.';
 $_['please_provide_token'] = 'Správnu adresu na aktualizáciu dopravcov nájdete na stránke modulu.';
 $_['cron_download_failed'] = 'Stiahnutie dopravcov sa nepodarilo: %s Skúste to prosím neskôr.';
+$_['cron_download_failed_generic'] = 'Stiahnutie feedu dopravcov sa nepodarilo.';
+$_['cron_download_failed_http'] = 'Stiahnutie feedu dopravcov sa nepodarilo s HTTP kódom %s.';
 $_['cron_empty_carriers'] = 'Nepodarilo sa získať ich zoznam.';
 $_['cron_invalid_carriers'] = 'Neplatná odpoveď API.';

--- a/upload/system/library/Packetery/API/CarriersDownloader.php
+++ b/upload/system/library/Packetery/API/CarriersDownloader.php
@@ -6,7 +6,10 @@ use Packetery\API\Exceptions\DownloadException;
 
 class CarriersDownloader
 {
-	const API_URL = 'https://www.zasilkovna.cz/api/v4/%s/branch.json?address-delivery';
+	const API_URL = 'https://pickup-point.api.packeta.com/v5/%s/carrier/json';
+	const HTTP_TIMEOUT = 5;
+	const ERROR_DOWNLOAD_FAILED = 'carrier_download_failed';
+	const ERROR_INVALID_JSON = 'carrier_invalid_json';
 
 	/** @var string */
 	private $apiKey;
@@ -25,9 +28,28 @@ class CarriersDownloader
 	 */
 	public function fetchAsArray()
 	{
-		$json = $this->downloadJson();
+		list($json, $httpCode) = $this->downloadJson();
+		$decoded = json_decode($json, true);
 
-		return $this->getFromJson($json);
+		$errorMessage = $this->extractFeedErrorMessage($decoded);
+		if ($errorMessage !== '') {
+			$errorCode = ($httpCode !== null ? (int)$httpCode : 0);
+			throw new DownloadException($errorMessage, $errorCode);
+		}
+
+		if ($httpCode !== null && $httpCode >= 400) {
+			throw new DownloadException(self::ERROR_DOWNLOAD_FAILED, (int)$httpCode);
+		}
+
+		if (isset($decoded[0]) && is_array($decoded[0])) {
+			return $decoded;
+		}
+
+		if ($decoded === []) {
+			return null;
+		}
+
+		throw new DownloadException(self::ERROR_INVALID_JSON);
 	}
 
 	/**
@@ -36,6 +58,18 @@ class CarriersDownloader
 	private function downloadJson()
 	{
 		$url = sprintf(self::API_URL, $this->apiKey);
+		$context = stream_context_create([
+			'http' => [
+				'method' => 'GET',
+				'timeout' => self::HTTP_TIMEOUT,
+				'protocol_version' => 1.1,
+				'ignore_errors' => true, // to capture error responses
+			],
+			'ssl' => [
+				'verify_peer' => true,
+				'verify_peer_name' => true,
+			],
+		]);
 
 		set_error_handler(
 			function ($severity, $message) {
@@ -43,24 +77,53 @@ class CarriersDownloader
 			}
 		);
 
-		$result = file_get_contents($url);
+		try {
+			$result = file_get_contents($url, false, $context);
+		} finally {
+			restore_error_handler();
+		}
 
-		restore_error_handler();
+		if ($result === false) {
+			throw new DownloadException(self::ERROR_DOWNLOAD_FAILED);
+		}
 
-		return $result;
+		$headers = isset($http_response_header) ? $http_response_header : [];
+		$httpCode = $this->getHttpStatusCodeFromHeaders($headers);
+
+		return [$result, $httpCode];
 	}
 
 	/**
-	 * @param string $json
-	 * @return array|null
+	 * @param mixed $decoded
+	 * @return string
 	 */
-	private function getFromJson($json)
+	private function extractFeedErrorMessage($decoded)
 	{
-		$carriersData = json_decode($json, true);
-		if (!isset($carriersData['carriers'])) {
+		if (!is_array($decoded)) {
+			return '';
+		}
+
+		if (isset($decoded['error']) && is_string($decoded['error']) && $decoded['error'] !== '') {
+			return $decoded['error'];
+		}
+
+		return '';
+	}
+
+	/**
+	 * @return int|null
+	 */
+	private function getHttpStatusCodeFromHeaders(array $headers)
+	{
+		if (!isset($headers[0]) || !is_string($headers[0])) {
 			return null;
 		}
 
-		return $carriersData['carriers'];
+		if (preg_match('/^HTTP\/\d+(?:\.\d+)?\s+(\d{3})(?:\s|$)/i', $headers[0], $matches) !== 1) {
+			return null;
+		}
+
+		return (int)$matches[1];
 	}
+
 }

--- a/upload/system/library/Packetery/Carrier/CarrierRepository.php
+++ b/upload/system/library/Packetery/Carrier/CarrierRepository.php
@@ -70,6 +70,7 @@ class CarrierRepository
 	public function getFilteredSorted(array $filter)
 	{
 		list($whereConditions, $ordering) = $this->getConditionsAndOrdering($filter);
+		array_unshift($whereConditions, '`available` = 1', '`deleted` = 0');
 		$whereClause = '';
 		if ($whereConditions) {
 			$whereClause = ' WHERE ' . implode(' AND ', $whereConditions);

--- a/upload/system/library/Packetery/Carrier/CarrierUpdater.php
+++ b/upload/system/library/Packetery/Carrier/CarrierUpdater.php
@@ -38,7 +38,8 @@ class CarrierUpdater
 				$carrier['requiresPhone'],
 				$carrier['requiresSize'],
 				$carrier['disallowsCod'],
-				$carrier['maxWeight']
+				$carrier['maxWeight'],
+				$carrier['available']
 			)) {
 				return false;
 			}
@@ -63,6 +64,7 @@ class CarrierUpdater
 			'requires_phone' => 'requiresPhone',
 			'requires_size' => 'requiresSize',
 			'disallows_cod' => 'disallowsCod',
+			'available' => 'available',
 		];
 
 		foreach ($carriers as $carrier) {
@@ -75,7 +77,7 @@ class CarrierUpdater
 				'deleted' => false,
 			];
 			foreach ($carrierBooleanParams as $columnName => $paramName) {
-				$carrierData[$columnName] = ($carrier[$paramName] === 'true');
+				$carrierData[$columnName] = ($carrier[$paramName] === 'true' || $carrier[$paramName] === true);
 			}
 			$mappedData[$carrierId] = $carrierData;
 		}


### PR DESCRIPTION
## Summary
- switch carrier feed download to Packeta v5 endpoint (`carrier/json?lang=en`) and parse v5 array response format
- persist carrier `available` state in `zasilkovna_carrier` (schema + migration + updater validation/mapping)
- show only active carriers in admin carrier list by filtering to `available = 1` and `deleted = 0`

## Test plan
- [ ] run carrier update cron with a valid token and API key
- [ ] verify no download error is thrown for the endpoint request
- [ ] verify `zasilkovna_carrier.available` exists (default `1`) after upgrade/migration
- [ ] verify carriers with `available = 0` are not displayed in admin carrier list
- [ ] verify module upgrade path from pre-2.1.5 completes without SQL errors