### PR TITLE
PES-3169: add cron URL copy action in module settings

### DIFF
--- a/upload/admin/language/cs-cz/extension/shipping/zasilkovna.php
+++ b/upload/admin/language/cs-cz/extension/shipping/zasilkovna.php
@@ -27,6 +27,8 @@ $_['text_all_countries']    	= 'Všechny země';
 // About extension
 $_['text_extension_version']    = 'Verze rošíření';
 $_['text_cron_url']             = 'URL pro aktualizaci dopravců pomocí cronu';
+$_['text_copy_cron_url_tooltip'] = 'Kliknutím zkopírujete url do schránky';
+$_['text_cron_url_copied']       = 'Zkopírováno!';
 
 // Text main settings form
 $_['entry_title']				= 'Název dopravy';

--- a/upload/admin/language/en-gb/extension/shipping/zasilkovna.php
+++ b/upload/admin/language/en-gb/extension/shipping/zasilkovna.php
@@ -27,6 +27,8 @@ $_['text_all_countries']		= 'All countries';
 // About extension
 $_['text_extension_version']	= 'Extension version';
 $_['text_cron_url']             = 'URL for updating carriers using cron';
+$_['text_copy_cron_url_tooltip'] = 'Click to copy the URL to clipboard';
+$_['text_cron_url_copied']       = 'Copied!';
 
 // Text main settings form
 $_['entry_title']				= 'Title';

--- a/upload/admin/language/sk-sk/extension/shipping/zasilkovna.php
+++ b/upload/admin/language/sk-sk/extension/shipping/zasilkovna.php
@@ -27,6 +27,8 @@ $_['text_all_countries'] = 'Všetky krajiny';
 // About extension
 $_['text_extension_version'] = 'Verzia rozšírenia';
 $_['text_cron_url'] = 'URL pre aktualizáciu dopravcov pomocou cronu';
+$_['text_copy_cron_url_tooltip'] = 'Kliknutím skopírujete url do schránky';
+$_['text_cron_url_copied'] = 'Skopírované!';
 
 // Text main settings form
 $_['entry_title'] = 'Názov dopravy';

--- a/upload/admin/view/template/extension/shipping/zasilkovna.twig
+++ b/upload/admin/view/template/extension/shipping/zasilkovna.twig
@@ -214,12 +214,55 @@
 				</p>
 				{% if shipping_zasilkovna_api_key %}
 					<p>
-						{{ text_cron_url }}: {{ cron_url }}
+						{{ text_cron_url }}:
 					</p>
+					<div class="input-group">
+						<input type="text" id="packetery-input-cron-url" class="form-control" value="{{ cron_url }}" readonly="readonly"/>
+						<span class="input-group-btn">
+							<button type="button" id="packetery-button-copy-cron-url" class="btn btn-default" data-toggle="tooltip" title="{{ text_copy_cron_url_tooltip }}">
+								<i class="fa fa-copy"></i>
+							</button>
+						</span>
+					</div>
+					<span id="packetery-text-cron-url-copied" class="text-success" style="display: none;">{{ text_cron_url_copied }}</span>
 				{% endif %}
 			</div>
 		</div>
 
 	</div>
 </div>
+<script type="text/javascript">
+	$('#packetery-button-copy-cron-url').on('click', function() {
+		var cronUrlInputElement = document.getElementById('packetery-input-cron-url');
+		var copiedTextElement = $('#packetery-text-cron-url-copied');
+
+		if (!cronUrlInputElement) {
+			return;
+		}
+
+		var showCopiedText = function() {
+			copiedTextElement.stop(true, true).fadeIn(150).delay(1200).fadeOut(250);
+		};
+
+		var cronUrl = cronUrlInputElement.value;
+
+		if (navigator.clipboard && navigator.clipboard.writeText) {
+			navigator.clipboard.writeText(cronUrl).then(function() {
+				showCopiedText();
+			}).catch(function() {
+				cronUrlInputElement.select();
+				document.execCommand('copy');
+				cronUrlInputElement.setSelectionRange(0, 0);
+				showCopiedText();
+			});
+
+			return;
+		}
+
+		cronUrlInputElement.select();
+		document.execCommand('copy');
+		cronUrlInputElement.setSelectionRange(0, 0);
+		showCopiedText();
+	});
+</script>
 {{ footer }}


### PR DESCRIPTION
## Summary
- add copy-to-clipboard UI for the carrier update cron URL in module settings
- keep cron URL in a readonly input and add a dedicated copy button with tooltip
- add localized copy tooltip/success texts for cs-cz, en-gb, and sk-sk

## Test plan
- [ ] Open admin -> Zasilkovna settings with API key configured and verify cron URL is shown in readonly input
- [ ] Hover copy button and verify tooltip text is displayed
- [ ] Click copy button and verify full cron URL is copied to clipboard
- [ ] Verify success feedback text is displayed after copy
- [ ] Verify behavior works in at least one modern browser and fallback manual selection remains available