### PR TITLE
PES-3171: add carrier detail editing and shipping rule storage

### DIFF
--- a/upload/admin/controller/extension/shipping/zasilkovna.php
+++ b/upload/admin/controller/extension/shipping/zasilkovna.php
@@ -28,6 +28,7 @@ require_once DIR_SYSTEM . 'library/Packetery/autoload.php';
  * @property ModelExtensionShippingZasilkovnaOrders $model_extension_shipping_zasilkovna_orders
  * @property ModelExtensionShippingZasilkovnaShippingRules $model_extension_shipping_zasilkovna_shipping_rules
  * @property ModelExtensionShippingZasilkovnaWeightRules $model_extension_shipping_zasilkovna_weight_rules
+ * @property ModelExtensionShippingZasilkovnaCarrierShippingRule $model_extension_shipping_zasilkovna_carrier_shipping_rule
  * @property Request $request
  * @property Response $response
  * @property Session $session
@@ -64,11 +65,15 @@ class ControllerExtensionShippingZasilkovna extends Controller {
 	const ACTION_ORDERS = 'orders';
 	const ACTION_ORDERS_EXPORT = 'orders_export';
 	const ACTION_ORDERS_UPDATE = 'orders_update';
+	const ACTION_CARRIERS = 'carriers';
+	const ACTION_CARRIERS_DETAIL = 'carriers_detail';
 
 	/** @var string name of url parameter for country code */
 	const PARAM_COUNTRY = 'country';
 	/** @var string name of url parameter for weight and shipping rule ID */
 	const PARAM_RULE_ID = 'rule_id';
+	/** @var string name of url parameter for carrier table record ID */
+	const PARAM_CARRIER_RECORD_ID = 'carrier_record_id';
 
 	// set of constants of url links to actions
 	const TEMPLATE_LINK_ADD = 'link_add';
@@ -787,7 +792,7 @@ class ControllerExtensionShippingZasilkovna extends Controller {
 			'menu_orders' => self::ACTION_ORDERS,
 			'menu_settings' => '',
 			'menu_pricing_rules' => 'pricing_rules',
-			'menu_carriers' => 'carriers',
+			'menu_carriers' => self::ACTION_CARRIERS,
 		];
 		$childrenMenus = [];
 		foreach ($subMenus as $translationKey => $action) {
@@ -943,7 +948,7 @@ class ControllerExtensionShippingZasilkovna extends Controller {
 	 */
 	public function carriers()
 	{
-		$data = $this->initPageData('carriers', 'text_carriers');
+		$data = $this->initPageData(self::ACTION_CARRIERS, 'text_carriers');
 		$data[self::TEMPLATE_LINK_BACK] = $this->createAdminLink('');
 
 		$filter = $this->request->get;
@@ -967,16 +972,88 @@ class ControllerExtensionShippingZasilkovna extends Controller {
 				'name' => $column,
 				'translation' => $this->language->get('column_carrier_' . $column),
 				'class' => $class,
-				'sortLink' => $this->createAdminLink('carriers', $sortLinkFilter),
+				'sortLink' => $this->createAdminLink(self::ACTION_CARRIERS, $sortLinkFilter),
 				'type' => $columnTypes[$column],
 			];
 		}
+		$data['columns']['action'] = [
+			'name' => 'action',
+			'translation' => $this->language->get('column_action'),
+			'class' => '',
+			'sortLink' => '',
+			'type' => 'action',
+		];
 
 		$data['user_token'] = $this->session->data['user_token'];
-		$data['carriers'] = $this->carrierRepository->getFilteredSorted($filter);
+		$carriers = $this->carrierRepository->getFilteredSorted($filter);
+		foreach ($carriers as &$carrier) {
+			$carrier[self::TEMPLATE_LINK_EDIT] = $this->createAdminLink(
+				self::ACTION_CARRIERS_DETAIL,
+				[self::PARAM_CARRIER_RECORD_ID => $carrier['id_record']]
+			);
+		}
+		unset($carrier);
+		$data['carriers'] = $carriers;
 		$data['filter'] = $filter;
 
 		$this->response->setOutput($this->load->view('extension/shipping/zasilkovna_carriers', $data));
+	}
+
+	/**
+	 * Handler for carrier detail.
+	 */
+	public function carriers_detail()
+	{
+		if (!isset($this->request->get[self::PARAM_CARRIER_RECORD_ID])) {
+			$this->load->language(self::ROUTING_BASE_PATH);
+			$this->session->data[self::TEMPLATE_MESSAGE_ERROR] = $this->language->get('error_missing_param');
+			$this->response->redirect($this->createAdminLink(self::ACTION_CARRIERS));
+		}
+
+		$carrierRecordId = (int)$this->request->get[self::PARAM_CARRIER_RECORD_ID];
+		$data = $this->initPageData(
+			self::ACTION_CARRIERS_DETAIL,
+			'text_carrier_detail',
+			[self::PARAM_CARRIER_RECORD_ID => $carrierRecordId]
+		);
+
+		$carrier = $this->carrierRepository->findByIdRecord($carrierRecordId);
+		if ($carrier === null) {
+			$this->session->data[self::TEMPLATE_MESSAGE_ERROR] = $this->language->get('error_missing_param');
+			$this->response->redirect($this->createAdminLink(self::ACTION_CARRIERS));
+		}
+
+		$this->load->model('extension/shipping/zasilkovna_carrier_shipping_rule');
+		if (($this->request->server['REQUEST_METHOD'] === 'POST') && $this->checkPermissions()) {
+			$this->model_extension_shipping_zasilkovna_carrier_shipping_rule->saveRule($carrierRecordId, $this->request->post);
+			$this->session->data[self::TEMPLATE_MESSAGE_SUCCESS] = $this->language->get('text_success');
+			$this->response->redirect(
+				$this->createAdminLink(self::ACTION_CARRIERS_DETAIL, [self::PARAM_CARRIER_RECORD_ID => $carrierRecordId])
+			);
+		}
+
+		$shippingRule = $this->model_extension_shipping_zasilkovna_carrier_shipping_rule->getRuleByCarrierId($carrierRecordId);
+		$isEnabled = (int)($shippingRule === [] ? 1 : $shippingRule['is_enabled']);
+		$defaultPrice = ($shippingRule === [] ? '' : $this->formatCarrierFormPrice($shippingRule['default_price']));
+		$freeShippingLimit = ($shippingRule === [] ? '' : $this->formatCarrierFormPrice($shippingRule['free_shipping_limit']));
+
+		if ($this->request->server['REQUEST_METHOD'] === 'POST') {
+			$isEnabled = (int)$this->request->post['is_enabled'];
+			$defaultPrice = $this->request->post['default_price'];
+			$freeShippingLimit = $this->request->post['free_shipping_limit'];
+		}
+
+		$data['carrier_name'] = $carrier->getName();
+		$data['is_enabled'] = $isEnabled;
+		$data['default_price'] = $defaultPrice;
+		$data['free_shipping_limit'] = $freeShippingLimit;
+		$data[self::TEMPLATE_LINK_FORM_ACTION] = $this->createAdminLink(
+			self::ACTION_CARRIERS_DETAIL,
+			[self::PARAM_CARRIER_RECORD_ID => $carrierRecordId]
+		);
+		$data[self::TEMPLATE_LINK_CANCEL] = $this->createAdminLink(self::ACTION_CARRIERS);
+
+		$this->response->setOutput($this->load->view('extension/shipping/zasilkovna_carrier_detail', $data));
 	}
 
 	/**
@@ -1057,6 +1134,24 @@ class ControllerExtensionShippingZasilkovna extends Controller {
 	}
 
 	/**
+	 * @param mixed $price
+	 * @return string
+	 */
+	private function formatCarrierFormPrice($price)
+	{
+		if ($price === null || $price === '') {
+			return '';
+		}
+
+		return number_format(
+			(float)$price,
+			ModelExtensionShippingZasilkovnaCarrierShippingRule::PRICE_DECIMAL_PRECISION,
+			'.',
+			''
+		);
+	}
+
+	/**
 	 * Check if user has permission to change module settings.
 	 *
 	 * @return bool TRUE = success, FALSE = error
@@ -1134,6 +1229,12 @@ class ControllerExtensionShippingZasilkovna extends Controller {
 			$data['breadcrumbs'][] = [
 				'text' => $this->language->get('text_pricing_rules'),
 				'href' => $this->createAdminLink('pricing_rules'),
+			];
+		}
+		if ($actionName === self::ACTION_CARRIERS_DETAIL) {
+			$data['breadcrumbs'][] = [
+				'text' => $this->language->get('text_carriers'),
+				'href' => $this->createAdminLink(self::ACTION_CARRIERS),
 			];
 		}
 		// last part of "breadcrumbs" is added only for nonempty action name (pages of module)

--- a/upload/admin/language/cs-cz/extension/shipping/zasilkovna.php
+++ b/upload/admin/language/cs-cz/extension/shipping/zasilkovna.php
@@ -12,6 +12,7 @@ $_['text_shipping_rules_list']	= 'Seznam pravidel dopravy';
 $_['text_order_list']			= 'Seznam objednávek';
 $_['text_pricing_rules']		= 'Cenová pravidla';
 $_['text_carriers']				= 'Dopravci Zásilkovny';
+$_['text_carrier_detail']        = 'Detail dopravce';
 
 // Menu
 $_['menu_title']				= 'Zásilkovna';

--- a/upload/admin/language/en-gb/extension/shipping/zasilkovna.php
+++ b/upload/admin/language/en-gb/extension/shipping/zasilkovna.php
@@ -12,6 +12,7 @@ $_['text_shipping_rules_list']	= 'Shipping rules list';
 $_['text_order_list']			= 'Order List';
 $_['text_pricing_rules']		= 'Pricing rules';
 $_['text_carriers']				= 'Packeta Carriers';
+$_['text_carrier_detail']        = 'Detail Carrier';
 
 // Menu
 $_['menu_title']				= 'Packeta';

--- a/upload/admin/language/sk-sk/extension/shipping/zasilkovna.php
+++ b/upload/admin/language/sk-sk/extension/shipping/zasilkovna.php
@@ -12,6 +12,7 @@ $_['text_shipping_rules_list'] = 'Zoznam pravidiel dopravy';
 $_['text_order_list'] = 'Zoznam objednávok';
 $_['text_pricing_rules'] = 'Cenové pravidlá';
 $_['text_carriers'] = 'Dopravcovia Packety';
+$_['text_carrier_detail'] = 'Detail dopravcu';
 
 // Menu
 $_['menu_title'] = 'Packeta';

--- a/upload/admin/model/extension/shipping/zasilkovna.php
+++ b/upload/admin/model/extension/shipping/zasilkovna.php
@@ -59,6 +59,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 		$this->db->query($sqlShippingRulesTable);
 
 		$this->db->query($this->getCreateCarriersTableSQL());
+		$this->db->query($this->getCreateCarrierShippingRulesTableSQL());
 		foreach ($this->getSaveInternalCarriersQueries() as $query) {
 			$this->db->query($query);
 		}
@@ -94,6 +95,22 @@ class ModelExtensionShippingZasilkovna extends Model {
 			PRIMARY KEY (`id_record`),
 			UNIQUE `id_source` (`id`, `source`)
 		) ENGINE=MyISAM;';
+	}
+
+	/**
+	 * @return string
+	 */
+	private function getCreateCarrierShippingRulesTableSQL()
+	{
+		return 'CREATE TABLE `' . DB_PREFIX . 'zasilkovna_carrier_shipping_rule` (
+			`id` int(11) NOT NULL AUTO_INCREMENT,
+			`carrier_id` int(11) NOT NULL,
+			`is_enabled` TINYINT(1) NOT NULL DEFAULT 1,
+			`default_price` decimal(10,2) NOT NULL DEFAULT 0,
+			`free_shipping_limit` decimal(10,2) NULL,
+			PRIMARY KEY (`id`),
+			UNIQUE KEY `carrier_id` (`carrier_id`)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8;';
 	}
 
 	/**
@@ -159,6 +176,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 
 		if ($oldVersion && version_compare($oldVersion, '2.1.5') < 0) {
 			$queries = array_merge($queries, $this->getSaveInternalCarriersQueries());
+			$queries[] = $this->getCreateCarrierShippingRulesTableSQL();
 		}
 
         foreach ($queries as $query) {
@@ -437,7 +455,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 	 */
 	public function deleteTablesAndEvents() {
 		// drop additional tables for extension module
-		$tableNames = ['zasilkovna_weight_rules', 'zasilkovna_shipping_rules', 'zasilkovna_orders', 'zasilkovna_carrier'];
+		$tableNames = ['zasilkovna_weight_rules', 'zasilkovna_shipping_rules', 'zasilkovna_orders', 'zasilkovna_carrier', 'zasilkovna_carrier_shipping_rule'];
 		foreach ($tableNames as $shortTableName) {
 			$sql = 'DROP TABLE IF EXISTS `' . DB_PREFIX . $shortTableName . '`;';
 			$this->db->query($sql);

--- a/upload/admin/model/extension/shipping/zasilkovna_carrier_shipping_rule.php
+++ b/upload/admin/model/extension/shipping/zasilkovna_carrier_shipping_rule.php
@@ -1,0 +1,64 @@
+<?php
+
+class ModelExtensionShippingZasilkovnaCarrierShippingRule extends Model
+{
+	const PRICE_DECIMAL_PRECISION = 2;
+
+	/**
+	 * @param int $carrierId
+	 * @return array{
+	 *   carrier_id: string,
+	 *   is_enabled: string,
+	 *   default_price: string,
+	 *   free_shipping_limit: ?string
+	 * }|array{}
+	 */
+	public function getRuleByCarrierId($carrierId)
+	{
+		$query = $this->db->query(
+			'SELECT `carrier_id`, `is_enabled`, `default_price`, `free_shipping_limit`
+			 FROM `' . DB_PREFIX . 'zasilkovna_carrier_shipping_rule`
+			 WHERE `carrier_id` = ' . (int)$carrierId . '
+			 LIMIT 1'
+		);
+
+		if (empty($query->rows)) {
+			return [];
+		}
+
+		return $query->row;
+	}
+
+	/**
+	 * @param int $carrierId
+	 * @param array{
+	 *   is_enabled: mixed,
+	 *   default_price: mixed,
+	 *   free_shipping_limit: mixed
+	 * } $data
+	 */
+	public function saveRule($carrierId, array $data)
+	{
+		$defaultPrice = round(
+			(float)str_replace(',', '.', (string)$data['default_price']),
+			self::PRICE_DECIMAL_PRECISION
+		);
+		$freeShippingLimitRawValue = str_replace(',', '.', (string)$data['free_shipping_limit']);
+		$freeShippingLimit = (
+			$freeShippingLimitRawValue === ''
+				? null
+				: round((float)$freeShippingLimitRawValue, self::PRICE_DECIMAL_PRECISION)
+		);
+
+		$this->db->query(
+			'REPLACE INTO `' . DB_PREFIX . 'zasilkovna_carrier_shipping_rule`
+			(`carrier_id`, `is_enabled`, `default_price`, `free_shipping_limit`)
+			VALUES (
+				' . (int)$carrierId . ',
+				' . (int)$data['is_enabled'] . ',
+				' . $defaultPrice . ',
+				' . ($freeShippingLimit === null ? 'NULL' : $freeShippingLimit) . '
+			)'
+		);
+	}
+}

--- a/upload/admin/view/template/extension/shipping/zasilkovna_carrier_detail.twig
+++ b/upload/admin/view/template/extension/shipping/zasilkovna_carrier_detail.twig
@@ -1,0 +1,62 @@
+{{ header }}{{ column_left }}
+<div id="content">
+  <div class="page-header">
+    <div class="container-fluid">
+      <div class="pull-right">
+        <button type="submit" form="form-carrier-detail" data-toggle="tooltip" title="{{ button_save }}" class="btn btn-primary"><i class="fa fa-save"></i></button>
+        <a href="{{ link_cancel }}" data-toggle="tooltip" title="{{ button_back }}" class="btn btn-default"><i class="fa fa-reply"></i></a>
+      </div>
+      <h1>{{ text_carriers }}</h1>
+      <ul class="breadcrumb">
+        {% for breadcrumb in breadcrumbs %}
+          <li><a href="{{ breadcrumb.href }}">{{ breadcrumb.text }}</a></li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  <div class="container-fluid">
+    {% if success %}
+      <div class="alert alert-success alert-dismissible"><i class="fa fa-check-circle"></i> {{ success }}
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+      </div>
+    {% endif %}
+    {% if error_warning %}
+      <div class="alert alert-danger alert-dismissible"><i class="fa fa-exclamation-circle"></i> {{ error_warning }}
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+      </div>
+    {% endif %}
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title"><i class="fa fa-pencil"></i> {{ carrier_name }}</h3>
+      </div>
+      <div class="panel-body">
+        <form action="{{ link_form_action }}" method="post" enctype="multipart/form-data" id="form-carrier-detail" class="form-horizontal">
+          <div class="form-group required">
+            <label class="col-sm-2 control-label" for="input-is-enabled">{{ entry_sr_is_enabled }}</label>
+            <div class="col-sm-10">
+              <select name="is_enabled" id="input-is-enabled" class="form-control">
+                <option value="1" {% if is_enabled == 1 %} selected="selected"{% endif %}>{{ text_enabled }}</option>
+                <option value="0" {% if is_enabled == 0 %} selected="selected"{% endif %}>{{ text_disabled }}</option>
+              </select>
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="col-sm-2 control-label" for="input-default-price">
+              <span data-toggle="tooltip" title="{{ help_default_shipping_rule_price }}">{{ entry_sr_default_price }}</span>
+            </label>
+            <div class="col-sm-10">
+              <input type="number" step="0.01" min="0" name="default_price" value="{{ default_price }}" placeholder="{{ entry_sr_default_price }}" id="input-default-price" class="form-control" />
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="col-sm-2 control-label" for="input-free-shipping-limit">{{ entry_sr_free_over_limit }}</label>
+            <div class="col-sm-10">
+              <input type="number" step="0.01" min="0" name="free_shipping_limit" value="{{ free_shipping_limit }}" placeholder="{{ entry_sr_free_over_limit }}" id="input-free-shipping-limit" class="form-control" />
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{{ footer }}

--- a/upload/admin/view/template/extension/shipping/zasilkovna_carriers.twig
+++ b/upload/admin/view/template/extension/shipping/zasilkovna_carriers.twig
@@ -26,21 +26,23 @@
                             <input type="hidden" name="user_token" value="{{ user_token }}">
 
                             {% for column in columns %}
-                                <div class="form-group">
-                                    <label class="control-label">{{ column.translation }}</label>
-                                    {% if column.type == 'text' or column.type == 'number' %}
-                                        <input type="{{ column.type }}" name="{{ column.name }}"
-                                               value="{{ filter[column.name] }}" class="form-control"/>
-                                    {% elseif column.type == 'bool' %}
-                                        <select name="{{ column.name }}" class="form-control">
-                                            <option value="">--</option>
-                                            <option {% if filter[column.name] == '1' %}selected="selected"{% endif %}
-                                                    value="1">{{ text_yes }}</option>
-                                            <option {% if filter[column.name] == '0' %}selected="selected"{% endif %}
-                                                    value="0">{{ text_no }}</option>
-                                        </select>
-                                    {% endif %}
-                                </div>
+                                {% if column.type != 'action' %}
+                                    <div class="form-group">
+                                        <label class="control-label">{{ column.translation }}</label>
+                                        {% if column.type == 'text' or column.type == 'number' %}
+                                            <input type="{{ column.type }}" name="{{ column.name }}"
+                                                   value="{{ filter[column.name] }}" class="form-control"/>
+                                        {% elseif column.type == 'bool' %}
+                                            <select name="{{ column.name }}" class="form-control">
+                                                <option value="">--</option>
+                                                <option {% if filter[column.name] == '1' %}selected="selected"{% endif %}
+                                                        value="1">{{ text_yes }}</option>
+                                                <option {% if filter[column.name] == '0' %}selected="selected"{% endif %}
+                                                        value="0">{{ text_no }}</option>
+                                            </select>
+                                        {% endif %}
+                                    </div>
+                                {% endif %}
                             {% endfor %}
 
                             <div class="form-group text-right">
@@ -56,10 +58,14 @@
                         <thead>
                         {% for column in columns %}
                             <td class="text-left">
-                                {% if column.class %}
-                                    <a href="{{ column.sortLink }}" class="{{ column.class }}">{{ column.translation }}</a>
+                                {% if column.type == 'action' %}
+                                    {{ column.translation }}
                                 {% else %}
-                                    <a href="{{ column.sortLink }}">{{ column.translation }}</a>
+                                    {% if column.class %}
+                                        <a href="{{ column.sortLink }}" class="{{ column.class }}">{{ column.translation }}</a>
+                                    {% else %}
+                                        <a href="{{ column.sortLink }}">{{ column.translation }}</a>
+                                    {% endif %}
                                 {% endif %}
                             </td>
                         {% endfor %}
@@ -75,11 +81,14 @@
                                     <td class="text-left">{% if carrier.is_pickup_points %} {{ text_yes }} {% else %} {{ text_no }} {% endif %}</td>
                                     <td class="text-left">{% if carrier.has_carrier_direct_label %} {{ text_yes }} {% else %} {{ text_no }} {% endif %}</td>
                                     <td class="text-left">{% if carrier.customs_declarations %} {{ text_yes }} {% else %} {{ text_no }} {% endif %}</td>
+                                    <td class="text-left">
+                                        <a href="{{ carrier.link_edit }}" data-toggle="tooltip" title="{{ button_edit }}"><i class="fa fa-pencil"></i></a>
+                                    </td>
                                 </tr>
                             {% endfor %}
                         {% else %}
                             <tr>
-                                <td class="text-center" colspan="7">{{ text_no_results }}</td>
+                                <td class="text-center" colspan="8">{{ text_no_results }}</td>
                             </tr>
                         {% endif %}
                         </tbody>

--- a/upload/system/library/Packetery/Carrier/Carrier.php
+++ b/upload/system/library/Packetery/Carrier/Carrier.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Packetery\Carrier;
+
+class Carrier
+{
+	/** @var int|null Packeta feed branch ID, not table primary key */
+	private $id;
+
+	/** @var int Table primary key with auto-increment */
+	private $idRecord;
+
+	/** @var string */
+	private $name;
+
+	/** @var string */
+	private $country;
+
+	/** @var string */
+	private $currency;
+
+	/** @var float */
+	private $maxWeight;
+
+	/** @var bool */
+	private $isPickupPoints;
+
+	/** @var bool */
+	private $hasCarrierDirectLabel;
+
+	/** @var bool */
+	private $customsDeclarations;
+
+	/** @var bool */
+	private $available;
+
+	/** @var bool */
+	private $deleted;
+
+	/**
+	 * @param int $idRecord Table primary key with auto-increment
+	 * @param int|null $id Packeta feed branch ID, not table primary key
+	 * @param string $name
+	 * @param string $country
+	 * @param string $currency
+	 * @param float $maxWeight
+	 * @param bool $isPickupPoints
+	 * @param bool $hasCarrierDirectLabel
+	 * @param bool $customsDeclarations
+	 * @param bool $available
+	 * @param bool $deleted
+	 */
+	public function __construct(
+		$idRecord,
+		$id,
+		$name,
+		$country,
+		$currency,
+		$maxWeight,
+		$isPickupPoints,
+		$hasCarrierDirectLabel,
+		$customsDeclarations,
+		$available,
+		$deleted
+	) {
+		$this->idRecord = $idRecord;
+		$this->id = $id;
+		$this->name = $name;
+		$this->country = $country;
+		$this->currency = $currency;
+		$this->maxWeight = round((float)$maxWeight, 3);
+		$this->isPickupPoints = (bool)$isPickupPoints;
+		$this->hasCarrierDirectLabel = (bool)$hasCarrierDirectLabel;
+		$this->customsDeclarations = (bool)$customsDeclarations;
+		$this->available = (bool)$available;
+		$this->deleted = (bool)$deleted;
+	}
+
+	/**
+	 * @return int|null
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
+}

--- a/upload/system/library/Packetery/Carrier/CarrierRepository.php
+++ b/upload/system/library/Packetery/Carrier/CarrierRepository.php
@@ -77,7 +77,16 @@ class CarrierRepository
 
 	/**
 	 * @param array $filter
-	 * @return mixed
+	 * @return array<int, array{
+	 *   id_record: int,
+	 *   name: string,
+	 *   country: string,
+	 *   currency: string,
+	 *   max_weight: string,
+	 *   is_pickup_points: string,
+	 *   has_carrier_direct_label: string,
+	 *   customs_declarations: string
+	 * }>
 	 */
 	public function getFilteredSorted(array $filter)
 	{
@@ -90,12 +99,67 @@ class CarrierRepository
 
 		/** @var StdClass $queryResult */
 		$queryResult = $this->db->query(
-			"SELECT `name`, `country`, `currency`, `max_weight`, `is_pickup_points`, `has_carrier_direct_label`, `customs_declarations`
+			"SELECT `id_record`, `name`, `country`, `currency`, `max_weight`, `is_pickup_points`, `has_carrier_direct_label`, `customs_declarations`
 			 FROM `" . DB_PREFIX . "zasilkovna_carrier`
 			 $whereClause
 			 ORDER BY $ordering"
 		);
 		return $queryResult->rows;
+	}
+
+	/**
+	 * @param int $idRecord
+	 * @return Carrier|null
+	 */
+	public function findByIdRecord($idRecord)
+	{
+		/** @var StdClass $queryResult */
+		$queryResult = $this->db->query(
+			"SELECT `id_record`, `id`, `name`, `country`, `currency`, `max_weight`, `is_pickup_points`,
+			 `has_carrier_direct_label`, `customs_declarations`, `available`, `deleted`
+			 FROM `" . DB_PREFIX . "zasilkovna_carrier`
+			 WHERE `id_record` = " . (int)$idRecord . "
+			 LIMIT 1"
+		);
+
+		if (empty($queryResult->rows)) {
+			return null;
+		}
+
+		return $this->mapRowToCarrier($queryResult->row);
+	}
+
+	/**
+	 * @param array{
+	 *   id_record: int,
+	 *   id: ?int,
+	 *   name: string,
+	 *   country: string,
+	 *   currency: string,
+	 *   max_weight: string|int|float,
+	 *   is_pickup_points: string|int|bool,
+	 *   has_carrier_direct_label: string|int|bool,
+	 *   customs_declarations: string|int|bool,
+	 *   available: string|int|bool,
+	 *   deleted: string|int|bool
+	 * } $row
+	 * @return Carrier
+	 */
+	private function mapRowToCarrier(array $row)
+	{
+		return new Carrier(
+			(int)$row['id_record'],
+			($row['id'] === null ? null : (int)$row['id']),
+			(string)$row['name'],
+			(string)$row['country'],
+			(string)$row['currency'],
+			(float)$row['max_weight'],
+			(bool)$row['is_pickup_points'],
+			(bool)$row['has_carrier_direct_label'],
+			(bool)$row['customs_declarations'],
+			(bool)$row['available'],
+			(bool)$row['deleted']
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- add non-sortable Action column with pencil edit links to `Packeta -> Carriers`
- add carrier detail page with `Enabled`, `Default price`, and `Free shipping limit` fields, including save flow and persistence
- introduce `zasilkovna_carrier_shipping_rule` storage (InnoDB), repository/model accessors, and localized detail title labels

## Test plan
- [x] open `Packeta -> Carriers` and verify `Action` column is last and non-sortable
- [x] click a carrier pencil icon and verify carrier detail page opens
- [x] change `Default price` and `Free shipping limit`, save, and verify success alert
- [x] reload detail and verify values are persisted
- [x] verify PHP 5.6 compatibility of new syntax