### PR TITLE
PES-3185: split widget by internal carrier vendor type

### DIFF
--- a/upload/admin/controller/extension/shipping/zasilkovna.php
+++ b/upload/admin/controller/extension/shipping/zasilkovna.php
@@ -38,7 +38,7 @@ require_once DIR_SYSTEM . 'library/Packetery/autoload.php';
  */
 class ControllerExtensionShippingZasilkovna extends Controller {
 
-    const VERSION = '2.1.10';
+    const VERSION = '2.1.11';
 	/** @var string base routing path for Zasilkovna module (controller action, language file, model) */
 	const ROUTING_BASE_PATH = 'extension/shipping/zasilkovna';
 	/** @var string routing path for zasilkovna orders model */

--- a/upload/admin/model/extension/shipping/zasilkovna.php
+++ b/upload/admin/model/extension/shipping/zasilkovna.php
@@ -1,7 +1,7 @@
 <?php
 
+use Packetery\Carrier\VendorGroup;
 use Packetery\Exceptions\UpgradeException;
-use Packetery\Widget\WidgetOptionsBuilder;
 
 require_once DIR_SYSTEM . 'library/Packetery/autoload.php';
 
@@ -355,7 +355,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 		return [
 			[
 				'name' => 'CZ Packeta Pick-up Point (Z-Point, Z-Box)',
-				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZBOX, WidgetOptionsBuilder::VENDOR_GROUP_ZPOINT],
+				'vendor_groups' => [VendorGroup::ZBOX, VendorGroup::ZPOINT],
 				'country' => 'cz',
 				'currency' => 'CZK',
 				'is_pickup_points' => 1,
@@ -372,7 +372,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'CZ Packeta Pick-up Point',
-				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZPOINT],
+				'vendor_groups' => [VendorGroup::ZPOINT],
 				'country' => 'cz',
 				'currency' => 'CZK',
 				'is_pickup_points' => 1,
@@ -389,7 +389,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'CZ Packeta Z-BOX',
-				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZBOX],
+				'vendor_groups' => [VendorGroup::ZBOX],
 				'country' => 'cz',
 				'currency' => 'CZK',
 				'is_pickup_points' => 1,
@@ -406,7 +406,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'SK Packeta Pick-up Point (Z-Point, Z-Box)',
-				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZBOX, WidgetOptionsBuilder::VENDOR_GROUP_ZPOINT],
+				'vendor_groups' => [VendorGroup::ZBOX, VendorGroup::ZPOINT],
 				'country' => 'sk',
 				'currency' => 'EUR',
 				'is_pickup_points' => 1,
@@ -423,7 +423,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'SK Packeta Pick-up Point',
-				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZPOINT],
+				'vendor_groups' => [VendorGroup::ZPOINT],
 				'country' => 'sk',
 				'currency' => 'EUR',
 				'is_pickup_points' => 1,
@@ -440,7 +440,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'SK Packeta Z-BOX',
-				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZBOX],
+				'vendor_groups' => [VendorGroup::ZBOX],
 				'country' => 'sk',
 				'currency' => 'EUR',
 				'is_pickup_points' => 1,
@@ -457,7 +457,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'HU Packeta Pick-up Point (Z-Point, Z-Box)',
-				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZBOX, WidgetOptionsBuilder::VENDOR_GROUP_ZPOINT],
+				'vendor_groups' => [VendorGroup::ZBOX, VendorGroup::ZPOINT],
 				'country' => 'hu',
 				'currency' => 'HUF',
 				'is_pickup_points' => 1,
@@ -474,7 +474,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'HU Packeta Pick-up Point',
-				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZPOINT],
+				'vendor_groups' => [VendorGroup::ZPOINT],
 				'country' => 'hu',
 				'currency' => 'HUF',
 				'is_pickup_points' => 1,
@@ -491,7 +491,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'HU Packeta Z-BOX',
-				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZBOX],
+				'vendor_groups' => [VendorGroup::ZBOX],
 				'country' => 'hu',
 				'currency' => 'HUF',
 				'is_pickup_points' => 1,
@@ -508,7 +508,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'RO Packeta Pick-up Point (Z-Point, Z-Box)',
-				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZBOX, WidgetOptionsBuilder::VENDOR_GROUP_ZPOINT],
+				'vendor_groups' => [VendorGroup::ZBOX, VendorGroup::ZPOINT],
 				'country' => 'ro',
 				'currency' => 'RON',
 				'is_pickup_points' => 1,
@@ -525,7 +525,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'RO Packeta Pick-up Point',
-				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZPOINT],
+				'vendor_groups' => [VendorGroup::ZPOINT],
 				'country' => 'ro',
 				'currency' => 'RON',
 				'is_pickup_points' => 1,
@@ -542,7 +542,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'RO Packeta Z-BOX',
-				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZBOX],
+				'vendor_groups' => [VendorGroup::ZBOX],
 				'country' => 'ro',
 				'currency' => 'RON',
 				'is_pickup_points' => 1,

--- a/upload/admin/model/extension/shipping/zasilkovna.php
+++ b/upload/admin/model/extension/shipping/zasilkovna.php
@@ -1,6 +1,7 @@
 <?php
 
 use Packetery\Exceptions\UpgradeException;
+use Packetery\Widget\WidgetOptionsBuilder;
 
 require_once DIR_SYSTEM . 'library/Packetery/autoload.php';
 
@@ -78,6 +79,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			`id_record` int(11) NOT NULL AUTO_INCREMENT,
 			`id` int NULL,
 			`name` varchar(255) NOT NULL,
+			`vendor_groups` varchar(255) NULL,
 			`is_pickup_points` boolean NOT NULL,
 			`has_carrier_direct_label` boolean NOT NULL,
 			`separate_house_number` boolean NOT NULL,
@@ -192,6 +194,11 @@ class ModelExtensionShippingZasilkovna extends Model {
 		}
 
 		if ($oldVersion && version_compare($oldVersion, '2.1.5') < 0) {
+			if (version_compare($oldVersion, '2.1.0') >= 0) {
+				$queries[] = "ALTER TABLE `" . DB_PREFIX . "zasilkovna_carrier`
+					ADD COLUMN `vendor_groups` varchar(255) NULL
+					AFTER `name`;";
+			}
 			$queries = array_merge($queries, $this->getSaveInternalCarriersQueries());
 			$queries[] = $this->getCreateCarrierShippingRulesTableSQL();
 		}
@@ -260,6 +267,39 @@ class ModelExtensionShippingZasilkovna extends Model {
 				ADD COLUMN `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 				AFTER `created_at`;";
 		}
+		if (
+			$oldVersion &&
+			version_compare($oldVersion, '2.1.5') >= 0 &&
+			version_compare($oldVersion, '2.1.11') < 0
+		) {
+			$queries[] = "ALTER TABLE `" . DB_PREFIX . "zasilkovna_carrier`
+				ADD COLUMN `vendor_groups` varchar(255) NULL
+				AFTER `name`;";
+			$queries[] = "UPDATE `" . DB_PREFIX . "zasilkovna_carrier`
+				SET `vendor_groups` = '[\"zbox\",\"zpoint\"]'
+				WHERE `source` = 'internal' AND `name` IN (
+					'CZ Packeta Pick-up Point (Z-Point, Z-Box)',
+					'SK Packeta Pick-up Point (Z-Point, Z-Box)',
+					'HU Packeta Pick-up Point (Z-Point, Z-Box)',
+					'RO Packeta Pick-up Point (Z-Point, Z-Box)'
+				);";
+			$queries[] = "UPDATE `" . DB_PREFIX . "zasilkovna_carrier`
+				SET `vendor_groups` = '[\"zpoint\"]'
+				WHERE `source` = 'internal' AND `name` IN (
+					'CZ Packeta Pick-up Point',
+					'SK Packeta Pick-up Point',
+					'HU Packeta Pick-up Point',
+					'RO Packeta Pick-up Point'
+				);";
+			$queries[] = "UPDATE `" . DB_PREFIX . "zasilkovna_carrier`
+				SET `vendor_groups` = '[\"zbox\"]'
+				WHERE `source` = 'internal' AND `name` IN (
+					'CZ Packeta Z-BOX',
+					'SK Packeta Z-BOX',
+					'HU Packeta Z-BOX',
+					'RO Packeta Z-BOX'
+				);";
+		}
         foreach ($queries as $query) {
             try {
                 $this->db->query($query);
@@ -282,14 +322,18 @@ class ModelExtensionShippingZasilkovna extends Model {
 		];
 
 		foreach ($carriers as $carrier) {
+			$vendorGroupsSql = $carrier['vendor_groups'] === null
+				? 'NULL'
+				: "'" . $this->db->escape(json_encode($carrier['vendor_groups'])) . "'";
 			$queries[] =
 				"INSERT INTO `" . DB_PREFIX . "zasilkovna_carrier`
-				(`id`, `name`, `is_pickup_points`, `has_carrier_direct_label`, `separate_house_number`,
+				(`id`, `name`, `vendor_groups`, `is_pickup_points`, `has_carrier_direct_label`, `separate_house_number`,
 				`customs_declarations`, `requires_email`, `requires_phone`, `requires_size`, `disallows_cod`,
 				`country`, `currency`, `max_weight`, `available`, `deleted`, `source`)
 				VALUES (
 					NULL,
 					'" . $this->db->escape($carrier['name']) . "',
+					" . $vendorGroupsSql . ",
 					" . (int)$carrier['is_pickup_points'] . ", " . (int)$carrier['has_carrier_direct_label'] . ",
 					" . (int)$carrier['separate_house_number'] . ", " . (int)$carrier['customs_declarations'] . ",
 					" . (int)$carrier['requires_email'] . ", " . (int)$carrier['requires_phone'] . ",
@@ -311,6 +355,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 		return [
 			[
 				'name' => 'CZ Packeta Pick-up Point (Z-Point, Z-Box)',
+				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZBOX, WidgetOptionsBuilder::VENDOR_GROUP_ZPOINT],
 				'country' => 'cz',
 				'currency' => 'CZK',
 				'is_pickup_points' => 1,
@@ -327,6 +372,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'CZ Packeta Pick-up Point',
+				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZPOINT],
 				'country' => 'cz',
 				'currency' => 'CZK',
 				'is_pickup_points' => 1,
@@ -343,6 +389,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'CZ Packeta Z-BOX',
+				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZBOX],
 				'country' => 'cz',
 				'currency' => 'CZK',
 				'is_pickup_points' => 1,
@@ -359,6 +406,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'SK Packeta Pick-up Point (Z-Point, Z-Box)',
+				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZBOX, WidgetOptionsBuilder::VENDOR_GROUP_ZPOINT],
 				'country' => 'sk',
 				'currency' => 'EUR',
 				'is_pickup_points' => 1,
@@ -375,6 +423,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'SK Packeta Pick-up Point',
+				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZPOINT],
 				'country' => 'sk',
 				'currency' => 'EUR',
 				'is_pickup_points' => 1,
@@ -391,6 +440,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'SK Packeta Z-BOX',
+				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZBOX],
 				'country' => 'sk',
 				'currency' => 'EUR',
 				'is_pickup_points' => 1,
@@ -407,6 +457,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'HU Packeta Pick-up Point (Z-Point, Z-Box)',
+				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZBOX, WidgetOptionsBuilder::VENDOR_GROUP_ZPOINT],
 				'country' => 'hu',
 				'currency' => 'HUF',
 				'is_pickup_points' => 1,
@@ -423,6 +474,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'HU Packeta Pick-up Point',
+				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZPOINT],
 				'country' => 'hu',
 				'currency' => 'HUF',
 				'is_pickup_points' => 1,
@@ -439,6 +491,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'HU Packeta Z-BOX',
+				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZBOX],
 				'country' => 'hu',
 				'currency' => 'HUF',
 				'is_pickup_points' => 1,
@@ -455,6 +508,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'RO Packeta Pick-up Point (Z-Point, Z-Box)',
+				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZBOX, WidgetOptionsBuilder::VENDOR_GROUP_ZPOINT],
 				'country' => 'ro',
 				'currency' => 'RON',
 				'is_pickup_points' => 1,
@@ -471,6 +525,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'RO Packeta Pick-up Point',
+				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZPOINT],
 				'country' => 'ro',
 				'currency' => 'RON',
 				'is_pickup_points' => 1,
@@ -487,6 +542,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 			],
 			[
 				'name' => 'RO Packeta Z-BOX',
+				'vendor_groups' => [WidgetOptionsBuilder::VENDOR_GROUP_ZBOX],
 				'country' => 'ro',
 				'currency' => 'RON',
 				'is_pickup_points' => 1,

--- a/upload/catalog/model/extension/shipping/zasilkovna.php
+++ b/upload/catalog/model/extension/shipping/zasilkovna.php
@@ -119,7 +119,7 @@ class ModelExtensionShippingZasilkovna extends Model {
 		$escapedCountryCode = $this->db->escape($countryCode);
 		$totalWeight = (float)$totalWeight;
 		$sql = "SELECT `c`.`id_record`, `c`.`id`, `c`.`name`, `c`.`country`, `c`.`currency`, `c`.`max_weight`, `c`.`is_pickup_points`,
-			 `c`.`has_carrier_direct_label`, `c`.`customs_declarations`, `c`.`available`, `c`.`deleted`
+			 `c`.`has_carrier_direct_label`, `c`.`customs_declarations`, `c`.`available`, `c`.`deleted`, `c`.`vendor_groups`
 			FROM `{$tableCarriers}` `c`
 			WHERE `c`.`available` = 1
 				AND `c`.`deleted` = 0
@@ -143,7 +143,8 @@ class ModelExtensionShippingZasilkovna extends Model {
 				(bool)$carrierRow['has_carrier_direct_label'],
 				(bool)$carrierRow['customs_declarations'],
 				(bool)$carrierRow['available'],
-				(bool)$carrierRow['deleted']
+				(bool)$carrierRow['deleted'],
+				($carrierRow['vendor_groups'] === null ? null : json_decode($carrierRow['vendor_groups'], true))
 			);
 		}
 

--- a/upload/system/library/Packetery/Carrier/Carrier.php
+++ b/upload/system/library/Packetery/Carrier/Carrier.php
@@ -37,6 +37,9 @@ class Carrier
 	/** @var bool */
 	private $deleted;
 
+	/** @var string[]|null */
+	private $vendorGroups;
+
 	/**
 	 * @param int $idRecord Table primary key with auto-increment
 	 * @param int|null $id Packeta feed branch ID, not table primary key
@@ -49,6 +52,7 @@ class Carrier
 	 * @param bool $customsDeclarations
 	 * @param bool $available
 	 * @param bool $deleted
+	 * @param string[]|null $vendorGroups
 	 */
 	public function __construct(
 		$idRecord,
@@ -61,7 +65,8 @@ class Carrier
 		$hasCarrierDirectLabel,
 		$customsDeclarations,
 		$available,
-		$deleted
+		$deleted,
+		$vendorGroups
 	) {
 		$this->idRecord = $idRecord;
 		$this->id = $id;
@@ -74,6 +79,7 @@ class Carrier
 		$this->customsDeclarations = (bool)$customsDeclarations;
 		$this->available = (bool)$available;
 		$this->deleted = (bool)$deleted;
+		$this->vendorGroups = $vendorGroups;
 	}
 
 	/**
@@ -114,5 +120,13 @@ class Carrier
 	public function isPickupPoints()
 	{
 		return $this->isPickupPoints;
+	}
+
+	/**
+	 * @return string[]|null
+	 */
+	public function getVendorGroups()
+	{
+		return $this->vendorGroups;
 	}
 }

--- a/upload/system/library/Packetery/Carrier/CarrierRepository.php
+++ b/upload/system/library/Packetery/Carrier/CarrierRepository.php
@@ -116,7 +116,7 @@ class CarrierRepository
 		/** @var StdClass $queryResult */
 		$queryResult = $this->db->query(
 			"SELECT `id_record`, `id`, `name`, `country`, `currency`, `max_weight`, `is_pickup_points`,
-			 `has_carrier_direct_label`, `customs_declarations`, `available`, `deleted`
+			 `has_carrier_direct_label`, `customs_declarations`, `available`, `deleted`, `vendor_groups`
 			 FROM `" . DB_PREFIX . "zasilkovna_carrier`
 			 WHERE `id_record` = " . (int)$idRecord . "
 			 LIMIT 1"
@@ -141,7 +141,8 @@ class CarrierRepository
 	 *   has_carrier_direct_label: string|int|bool,
 	 *   customs_declarations: string|int|bool,
 	 *   available: string|int|bool,
-	 *   deleted: string|int|bool
+	 *   deleted: string|int|bool,
+	 *   vendor_groups: ?string
 	 * } $row
 	 * @return Carrier
 	 */
@@ -158,7 +159,8 @@ class CarrierRepository
 			(bool)$row['has_carrier_direct_label'],
 			(bool)$row['customs_declarations'],
 			(bool)$row['available'],
-			(bool)$row['deleted']
+			(bool)$row['deleted'],
+			($row['vendor_groups'] === null ? null : json_decode($row['vendor_groups'], true))
 		);
 	}
 

--- a/upload/system/library/Packetery/Carrier/CarrierUpdater.php
+++ b/upload/system/library/Packetery/Carrier/CarrierUpdater.php
@@ -71,6 +71,7 @@ class CarrierUpdater
 			$carrierId = (int)$carrier['id'];
 			$carrierData = [
 				'name' => $carrier['name'],
+				'vendor_groups' => null,
 				'country' => strtolower((string)$carrier['country']),
 				'currency' => $carrier['currency'],
 				'max_weight' => (float)$carrier['maxWeight'],

--- a/upload/system/library/Packetery/Carrier/VendorGroup.php
+++ b/upload/system/library/Packetery/Carrier/VendorGroup.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packetery\Carrier;
+
+/**
+ * Vendor group identifiers attached to a carrier.
+ *
+ * These values are the carrier domain marker for which Packeta vendor types
+ * a carrier supports. {@see ZBOX} is also the literal string sent to the
+ * widget API as the `group` parameter for Z-Box vendors. {@see ZPOINT} is
+ * a PHP-internal marker only — Z-Point is the widget API's implicit default,
+ * so the `'zpoint'` value is never sent to the widget.
+ */
+class VendorGroup
+{
+	public const ZBOX = 'zbox';
+	public const ZPOINT = 'zpoint';
+}

--- a/upload/system/library/Packetery/Widget/WidgetOptionsBuilder.php
+++ b/upload/system/library/Packetery/Widget/WidgetOptionsBuilder.php
@@ -7,6 +7,7 @@ use Packetery\Carrier\Carrier;
 class WidgetOptionsBuilder
 {
 	const VENDOR_GROUP_ZBOX = 'zbox';
+	const VENDOR_GROUP_ZPOINT = 'zpoint';
 
 	/**
 	 * @param string $language
@@ -58,10 +59,21 @@ class WidgetOptionsBuilder
 			];
 		}
 
-		return [
-			$this->createZPointVendor($carrier->getCountry()),
-			$this->createZBoxVendor($carrier->getCountry()),
-		];
+		$vendorGroups = $carrier->getVendorGroups();
+		if ($vendorGroups === null) {
+			return [];
+		}
+
+		$vendors = [];
+		foreach ($vendorGroups as $group) {
+			if ($group === self::VENDOR_GROUP_ZBOX) {
+				$vendors[] = $this->createZBoxVendor($carrier->getCountry());
+			} else if ($group === self::VENDOR_GROUP_ZPOINT) {
+				$vendors[] = $this->createZPointVendor($carrier->getCountry());
+			}
+		}
+
+		return $vendors;
 	}
 
 	/**

--- a/upload/system/library/Packetery/Widget/WidgetOptionsBuilder.php
+++ b/upload/system/library/Packetery/Widget/WidgetOptionsBuilder.php
@@ -3,12 +3,10 @@
 namespace Packetery\Widget;
 
 use Packetery\Carrier\Carrier;
+use Packetery\Carrier\VendorGroup;
 
 class WidgetOptionsBuilder
 {
-	const VENDOR_GROUP_ZBOX = 'zbox';
-	const VENDOR_GROUP_ZPOINT = 'zpoint';
-
 	/**
 	 * @param string $language
 	 * @param string $appIdentity
@@ -66,9 +64,9 @@ class WidgetOptionsBuilder
 
 		$vendors = [];
 		foreach ($vendorGroups as $group) {
-			if ($group === self::VENDOR_GROUP_ZBOX) {
+			if ($group === VendorGroup::ZBOX) {
 				$vendors[] = $this->createZBoxVendor($carrier->getCountry());
-			} else if ($group === self::VENDOR_GROUP_ZPOINT) {
+			} else if ($group === VendorGroup::ZPOINT) {
 				$vendors[] = $this->createZPointVendor($carrier->getCountry());
 			}
 		}
@@ -96,7 +94,7 @@ class WidgetOptionsBuilder
 	{
 		return [
 			'country' => $country,
-			'group' => self::VENDOR_GROUP_ZBOX,
+			'group' => VendorGroup::ZBOX,
 			'selected' => true,
 		];
 	}


### PR DESCRIPTION
## Summary

Implements the split feature from [PES-3185](https://packeta.atlassian.net/browse/PES-3185): the Packeta widget now filters pickup points to match the vendor type of the selected internal carrier.

- Adds `vendor_groups` (`varchar(255) NULL`) column to `zasilkovna_carrier`; stores a JSON-encoded list of `zbox` / `zpoint` group identifiers per internal carrier.
- Reads the column in `CarrierRepository` and `catalog/model/.../zasilkovna`, exposes it on the `Carrier` entity.
- `WidgetOptionsBuilder::getWidgetVendorsParam()` now emits one widget vendor entry per configured group, so:
  - `["zpoint"]` carriers show only Z-Points,
  - `["zbox"]` carriers show only Z-BOXes,
  - `["zbox","zpoint"]` carriers show both.
- Covers all four supported countries (CZ, SK, HU, RO) in the seed data and in the upgrade backfill.
- Schema migration to 2.1.11: adds the column for upgrades from any 2.1.x baseline (including 2.1.0–2.1.4, where `getSaveInternalCarriersQueries()` is replayed) and backfills `vendor_groups` for existing internal-carrier rows by canonical name (user-edited names live in `zasilkovna_carrier_shipping_rule.carrier_name`, so renames don't break the match).
- Hand-built INSERT in `getSaveInternalCarriersQueries()` emits SQL `NULL` (not the string `'null'`) when `vendor_groups` is null.

## Test plan

- [x] Upgrade from `2.1.5`–`2.1.10`: ALTER adds the column; backfill UPDATEs populate vendor_groups for the 12 canonical internal carriers across CZ/SK/HU/RO.
- [x] Checkout, ZPoint-only internal carrier selected → widget shows only Z-Point pickup points, no Z-BOXes.
- [x] Checkout, Z-BOX-only internal carrier selected → widget shows only Z-BOXes.
- [x] Checkout, combined "Pick-up Point (Z-Point, Z-Box)" carrier selected → widget shows both vendor types.
- [x] Repeat the three checkout scenarios for each of CZ, SK, HU, RO.
- [x] Order cannot be completed without selecting a concrete pickup point in the widget (PES-3153 behavior preserved).

[PES-3185]: https://packeta.atlassian.net/browse/PES-3185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ